### PR TITLE
possible fix for #8

### DIFF
--- a/bin/key-mapper-control
+++ b/bin/key-mapper-control
@@ -75,11 +75,20 @@ def main(options, daemon, xmodmap_path):
 
     if options.command == AUTOLOAD:
         daemon.stop()
-        for device, preset in config.iterate_autoload_presets():
-            mapping = Mapping()
-            preset_path = get_preset_path(device, preset)
-            mapping.load(preset_path)
-            daemon.start_injecting(device, preset_path, xmodmap_path)
+        for device_start, device_value in config.iterate_autoload_presets():
+            devices = []
+            if type(device_value) is dict:
+                for device_end, preset in device_value.items():
+                    devices.append((device_start + device_end, preset))
+            else:
+                devices.append((device_start, device_value))
+
+            # apply all presets found
+            for device, preset in devices:
+                mapping = Mapping()
+                preset_path = get_preset_path(device, preset)
+                mapping.load(preset_path)
+                daemon.start_injecting(device, preset_path, xmodmap_path)
 
     if options.command == START:
         if options.device is None:


### PR DESCRIPTION
The config supports manufacturer sub-categorization and the autoload function does not. This adds support to the autoload function for sub-categorization of keyboards.