### PR TITLE
Add systemctl enable for PIP install

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ sudo apt install ./dist/key-mapper-0.6.1.deb
 
 ```bash
 sudo pip install git+https://github.com/sezanzeb/key-mapper.git
+sudo systemctl enable key-mapper
 sudo systemctl restart key-mapper
 ```
 


### PR DESCRIPTION
Thank you for this great tool!

After my PIP installation, I just noticed the `sudo systemctl enable key-mapper` was missing in installation steps to get the configuration back after reboot (same steps as https://github.com/sezanzeb/key-mapper/blob/main/DEBIAN/postinst).