### PR TITLE
Add GObject dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,8 @@ setup(
     install_requires=[
         'setuptools',
         'evdev',
-        'pydbus'
+        'pydbus',
+        'pygobject',
     ],
     cmdclass={
         'install': Install,


### PR DESCRIPTION
key-mapper needs gi, GLib, and Gtk at runtime; this ensures they are available.

Signed-off-by: Stephen Kitt <steve@sk2.org>