### PR TITLE
Halt waits in h() when key is released - enables different actions depending on key press length

### DIFF
--- a/keymapper/injection/macros.py
+++ b/keymapper/injection/macros.py
@@ -226,8 +226,14 @@ class _Macro:
             # that receive the handler as an argument, so that they know
             # where to send the event to.
             coroutine = task(handler)
+
+            if (self.is_holding() == False and coroutine.__name__ == "sleep"):
+                break
+
             if asyncio.iscoroutine(coroutine):
                 await coroutine
+                if (self.is_holding() == False and coroutine.__name__ == "sleep"):
+                    break
 
         # done
         self.running = False
@@ -447,10 +453,14 @@ class _Macro:
                 f'a number, but got "{sleeptime}"'
             ) from error
 
-        sleeptime /= 1000
-
+       
         async def sleep(_):
-            await asyncio.sleep(sleeptime)
+            """ Wait in intervals of 10ms so the wait can be ended early if the key is released """
+            for i in range(int(sleeptime/10)):
+                await asyncio.sleep(0.01)
+                if (self.is_holding() == False):
+                    break
+                
 
         self.tasks.append(sleep)
 


### PR DESCRIPTION
I created  an issue #120 for this but I was able to implement it myself.

This enables the creation of macros which do different things depending on how long the button has been pressed:

# Functionality

## Long press / short press

```
set("pressed", 1).h(w(500).set("pressed",0)).ifeq("pressed", 1, k(x), k(y))
```

If the button is released within 500ms it prints `x` if it's released after 500ms it prints `y`. 


## Tap / hold

```
set("pressed", 1).h(w(100).set("pressed",0).h(y)).ifeq("pressed", 1, k(x), k(y))
```

On tap (button released within 100ms) prints `x` after 100ms it acts like `y` is being held down. 

# Implementation

The main change is in the `run` method:


```python
        for task in self.tasks:
            # one could call tasks the compiled macros. it's lambda functions
            # that receive the handler as an argument, so that they know
            # where to send the event to.
            coroutine = task(handler)

            if (self.is_holding() == False and coroutine.__name__ == "sleep"):
                break

            if asyncio.iscoroutine(coroutine):
                await coroutine
                if (self.is_holding() == False and coroutine.__name__ == "sleep"):
                    break
```

If the button has been released and the next task is `wait`   then it stops running any further tasks. E.g. if the button is released during the wait of `w(500).k(y)`  then `k(y)` will never get executed. This is done twice because the key could be released before the loop runs or during the `await`.

The second change is the sleep function:


```py
        async def sleep(_):
            """ Wait in intervals of 10ms so the wait can be ended early if the key is released """
            for i in range(int(sleeptime/10)):
                await asyncio.sleep(0.01)
                if (self.is_holding() == False):
                    break

```

Instead of `await asyncio.sleep(sleeptime/1000)` it chunks the waits into 10ms intervals. Without this in the example above, tapping and releasing the key would make the `x` appear only after the wait timer had finished (e.g. 500ms). This reduces the input lag to 10ms max.