### PR TITLE
minor: fix grammar with logging error

### DIFF
--- a/keymapper/daemon.py
+++ b/keymapper/daemon.py
@@ -208,7 +208,7 @@ class Daemon:
         try:
             bus.publish(BUS_NAME, self)
         except RuntimeError as error:
-            logger.error('Is the service is already running? %s', str(error))
+            logger.error('Is the service already running? (%s)', str(error))
             sys.exit(1)
 
     def run(self):


### PR DESCRIPTION
I came across this while trying out key-mapper.

Fixes a small grammar mistake/type, and adds the error in parenthesis, which makes it a bit clearer where it starts/ends.

I got the following there:

> ERROR: Is the service is already running? g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Connection ":1.329" is not allowed to own the service "keymapper.Control" due to security polici…

(this happened when installing it on Arch Linux, and worked after restarting the service - not sure what happened there)